### PR TITLE
DOC: fix typos in user guide

### DIFF
--- a/doc/source/user_guide/groupby.rst
+++ b/doc/source/user_guide/groupby.rst
@@ -418,7 +418,7 @@ You can also include the grouping columns if you want to operate on them.
 
 .. note::
 
-   The ``groupby`` operation in Pandas drops the ``name`` field of the columns Index object
+   The ``groupby`` operation in pandas drops the ``name`` field of the columns Index object
    after the operation. This change ensures consistency in syntax between different
    column selection methods within groupby operations.
 

--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -990,7 +990,7 @@ Thousand separators
 
 For large numbers that have been written with a thousands separator, you can
 set the ``thousands`` keyword to a string of length 1 so that integers will be parsed
-correctly:
+correctly.
 
 By default, numbers with a thousands separator will be parsed as strings:
 

--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -979,7 +979,7 @@ nearest key rather than equal keys. For each row in the ``left`` :class:`DataFra
 the last row in the ``right`` :class:`DataFrame` are selected where the ``on`` key is less
 than the left's key. Both :class:`DataFrame` must be sorted by the key.
 
-Optionally an :func:`merge_asof` can perform a group-wise merge by matching the
+Optionally :func:`merge_asof` can perform a group-wise merge by matching the
 ``by`` key in addition to the nearest match on the ``on`` key.
 
 .. ipython:: python

--- a/doc/source/user_guide/merging.rst
+++ b/doc/source/user_guide/merging.rst
@@ -586,7 +586,7 @@ A string argument to ``indicator`` will use the value as the name for the indica
 Overlapping value columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The merge ``suffixes`` argument takes a tuple of list of strings to append to
+The merge ``suffixes`` argument takes a tuple or list of strings to append to
 overlapping column names in the input :class:`DataFrame` to disambiguate the result
 columns:
 

--- a/doc/source/user_guide/scale.rst
+++ b/doc/source/user_guide/scale.rst
@@ -5,7 +5,7 @@ Scaling to large datasets
 *************************
 
 pandas provides data structures for in-memory analytics, which makes using pandas
-to analyze datasets that are larger than memory datasets somewhat tricky. Even datasets
+to analyze datasets that are larger than memory somewhat tricky. Even datasets
 that are a sizable fraction of memory become unwieldy, as some pandas operations need
 to make intermediate copies.
 

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1580,7 +1580,7 @@ the pandas objects.
    ts = ts[:5]
    ts.shift(1)
 
-The ``shift`` method accepts an ``freq`` argument which can accept a
+The ``shift`` method accepts a ``freq`` argument which can accept a
 ``DateOffset`` class or other ``timedelta``-like object or also an
 :ref:`offset alias <timeseries.offset_aliases>`.
 

--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -2570,7 +2570,7 @@ because daylight savings time (DST) in a local time zone causes some times to oc
 twice within one day ("clocks fall back"). The following options are available:
 
 * ``'raise'``: Raises a ``ValueError`` (the default behavior)
-* ``'infer'``: Attempt to determine the correct offset base on the monotonicity of the timestamps
+* ``'infer'``: Attempt to determine the correct offset based on the monotonicity of the timestamps
 * ``'NaT'``: Replaces ambiguous times with ``NaT``
 * ``bool``: ``True`` represents a DST time, ``False`` represents non-DST time. An array-like of ``bool`` values is supported for a sequence of times.
 


### PR DESCRIPTION
Fixed a few typos in the user guide.